### PR TITLE
Fix make generate provider name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-provider "scaffolding" {
+provider "corax" {
   # example configuration here
 }
 ```

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -19,4 +19,4 @@ import (
 //go:generate terraform fmt -recursive ../examples/
 
 // Generate documentation.
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir .. -provider-name scaffolding
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir .. -provider-name corax


### PR DESCRIPTION
## Summary
- set correct provider name `corax` for docs generation
- fix provider name in example usage of docs

## Testing
- `make generate`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684bf47304308328ab0002d3532b6a8d